### PR TITLE
Show usage when run with no arguments

### DIFF
--- a/src/cert-chain-resolver.sh
+++ b/src/cert-chain-resolver.sh
@@ -97,8 +97,13 @@ parse_opts() {
 
   if [ -n "$1" ]; then
     INPUT_FILENAME="$1"
+  elif [ -t 0 ]; then
+    # stdin is not available
+    usage
+    return 1
   fi
 
+  # Retained for backward compatibility
   if [ -n "$2" ]; then
     OUTPUT_FILENAME="$2"
   fi


### PR DESCRIPTION
Fail and show usage when no input file is specified, and no input is
being piped in on stdin.
