### PR TITLE
to suppoet bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ NOTE: The shell script is **deprecated**. Check [master](https://github.com/zakj
 
 ## Dependencies
 
-- wget
+- wget or curl
 - OpenSSL
 
 ## Usage

--- a/src/cert-chain-resolver.sh
+++ b/src/cert-chain-resolver.sh
@@ -18,6 +18,11 @@ set -eu
 alias command_exists="type >/dev/null 2>&1"
 alias echoerr="echo >&2"
 
+if command_exists curl; then
+  alias get_issuer="curl -so- "
+elif command_exists wget; then
+  alias get_issuer="wget -qO- "
+fi
 
 INPUT_FILENAME="/dev/stdin"
 OUTPUT_FILENAME="/dev/stdout"
@@ -80,9 +85,11 @@ usage() {
 }
 
 check_dependencies() {
-  if ! command_exists wget; then
-    echoerr "Error: wget is required"
-    return 1
+  if ! command_exists curl; then
+    if ! command_exists wget; then
+      echoerr "Error: wget or curl is required"
+      return 1
+    fi
   fi
 
   if ! command_exists openssl; then
@@ -157,7 +164,7 @@ main() {
     fi
 
     # download issuer's certificate, normalize to PEM
-    if ! CURRENT_CERT="$(wget -q -O - "$ISSUER_CERT_URL" | cert_normalize_to_pem)"; then
+    if ! CURRENT_CERT="$(get_issuer "$ISSUER_CERT_URL" | cert_normalize_to_pem)"; then
       return 1
     fi
 

--- a/src/cert-chain-resolver.sh
+++ b/src/cert-chain-resolver.sh
@@ -7,6 +7,11 @@
 # Copyright (c) 2015 Jan Žák (http://zakjan.cz)
 # The MIT License (MIT).
 
+if [ "$BASH_VERSION" != '' ]; then
+    #run by bash.
+    shopt -s expand_aliases
+fi
+
 set -eu
 
 


### PR DESCRIPTION
when using bash, Aliases are not expanded when the shell is not interactive, unless the expand_aliases shell option is set using shopt.